### PR TITLE
Removed gosu from replication.sh updated postgres

### DIFF
--- a/20-replication.sh
+++ b/20-replication.sh
@@ -7,11 +7,11 @@ if [ $REPLICATION_ROLE = "master" ]; then
 elif [ $REPLICATION_ROLE = "slave" ]; then
     # stop postgres instance and reset PGDATA,
     # confs will be copied by pg_basebackup
-    gosu postgres pg_ctl -D "$PGDATA" -m fast -w stop
+    pg_ctl -D "$PGDATA" -m fast -w stop
     # make sure standby's data directory is empty
     rm -r "$PGDATA"/*
 
-    gosu postgres pg_basebackup \
+    pg_basebackup \
          --write-recovery-conf \
          --pgdata="$PGDATA" \
          --xlog-method=fetch \
@@ -22,7 +22,7 @@ elif [ $REPLICATION_ROLE = "slave" ]; then
          --verbose
 
     # useless postgres start to fullfil docker-entrypoint.sh stop
-    gosu postgres pg_ctl -D "$PGDATA" \
+    pg_ctl -D "$PGDATA" \
          -o "-c listen_addresses=''" \
          -w start
 fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # -*- mode: conf -*-
-FROM postgres:9.5
+FROM postgres:9.6
 
 MAINTAINER me@nebirhos.com
 


### PR DESCRIPTION
Something has changed in recent versions of the postgres image that
breaks the use of gosu (or rather, makes it useless). See
https://github.com/docker-library/postgres/issues/269. It created an
error when the script was creating a slave instnace (see issue #4).

Also updated the Dockerfile to use the 9.6 version of the Docker image.

Fixes #4 