### PR TITLE
Add compatibily for PG 12.3

### DIFF
--- a/10-config.sh
+++ b/10-config.sh
@@ -15,3 +15,5 @@ echo "hot_standby = on" >> "$PGDATA/postgresql.conf"
 
 
 echo "host replication $REPLICATION_USER 0.0.0.0/0 trust" >> "$PGDATA/pg_hba.conf"
+
+pg_ctl -D "$PGDATA" -m fast -w reload

--- a/20-replication.sh
+++ b/20-replication.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ $REPLICATION_ROLE = "master" ]; then
-    psql -U postgres -c "CREATE ROLE $REPLICATION_USER WITH REPLICATION PASSWORD '$REPLICATION_PASSWORD' LOGIN"
+    psql -U $POSTGRES_USER -c "CREATE ROLE $REPLICATION_USER WITH REPLICATION PASSWORD '$REPLICATION_PASSWORD' LOGIN"
 
 elif [ $REPLICATION_ROLE = "slave" ]; then
     # stop postgres instance and reset PGDATA,
@@ -14,7 +14,7 @@ elif [ $REPLICATION_ROLE = "slave" ]; then
     pg_basebackup \
          --write-recovery-conf \
          --pgdata="$PGDATA" \
-         --xlog-method=fetch \
+         --wal-method=fetch \
          --username=$REPLICATION_USER \
          --host=$POSTGRES_MASTER_SERVICE_HOST \
          --port=$POSTGRES_MASTER_SERVICE_PORT \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # -*- mode: conf -*-
-FROM postgres:9.6
+FROM postgres:12.3
 
 MAINTAINER me@nebirhos.com
 
@@ -16,6 +16,9 @@ ENV REPLICATION_PASSWORD ""
 # slave settings
 ENV POSTGRES_MASTER_SERVICE_HOST localhost
 ENV POSTGRES_MASTER_SERVICE_PORT 5432
+
+# postgres settings
+ENV POSTGRES_USER postgres
 
 COPY 10-config.sh /docker-entrypoint-initdb.d/
 COPY 20-replication.sh /docker-entrypoint-initdb.d/

--- a/README.md
+++ b/README.md
@@ -1,45 +1,94 @@
-Postgres Streaming Replication
-==============================
+# Postgres Streaming Replication
 
 [![Build Status](https://travis-ci.org/nebirhos/docker-postgres-replication.svg?branch=master)](https://travis-ci.org/nebirhos/docker-postgres-replication)
-[![](https://imagelayers.io/badge/nebirhos/postgres-replication:latest.svg)](https://imagelayers.io/?images=nebirhos/postgres-replication:latest 'Get your own badge on imagelayers.io')
-
+[![](https://imagelayers.io/badge/nebirhos/postgres-replication:latest.svg)](https://imagelayers.io/?images=nebirhos/postgres-replication:latest "Get your own badge on imagelayers.io")
 
 Enhanced version of the official Postgres image to support streaming replication
 out of the box.
 
 Postgres-replication is meant to be used with orchestration systems such as Kubernetes.
 
+## Tags
 
-Tags
-----
-
-Images are automatically updated when the [official postgres image](https://hub.docker.com/_/postgres/)
-is updated.
+Images are automatically updated when the [official postgres image](https://hub.docker.com/_/postgres/) is updated.
 
 Supported tags:
 
-* 9.6, 9, latest ([9.6](https://github.com/nebirhos/docker-postgres-replication/tree/9.6))
-* 9.5 ([9.5](https://github.com/nebirhos/docker-postgres-replication/tree/9.5))
+- 9.6, 9, latest ([9.6](https://github.com/nebirhos/docker-postgres-replication/tree/9.6))
+- 9.5 ([9.5](https://github.com/nebirhos/docker-postgres-replication/tree/9.5))
+- 12.3 ([12.3](https://github.com/nebirhos/docker-postgres-replication/tree/12.3))
 
+## Run with Docker Compose
 
-Run with Docker Compose
------------------------
-
-```
+```sh
 docker-compose up
 ```
 
+Then you can try to make somes changes on master
 
-Run with Docker
----------------
+```sh
+docker exec -it docker-postgres-replication_postgres-master_1 psql -U postgres
+```
+
+```sql
+postgres=# create database test;
+postgres=# \c test
+test=# create table posts (title text);
+test=# insert into posts values ('it works');
+```
+
+Then changes will appear on slave
+
+```sh
+docker exec docker-postgres-replication_postgres-slave_1 psql -U postgres test -c 'select * from posts'
+  title
+----------
+ it works
+(1 row)
+```
+
+### Exemple of `docker-compose.yml`
+
+```yml
+version: "3.3"
+services:
+  postgres:
+    image: nebirhos/postgres-replication:12.3
+    shm_size: "2gb"
+    environment:
+      POSTGRES_USER: nebirhos
+      POSTGRES_PASSWORD: password
+      REPLICATION_USER: nebirhos_rep
+      REPLICATION_PASSWORD: password
+    ports:
+      - 5432:5432
+    expose:
+      - 5432
+
+  postgres-slave:
+    image: nebirhos/postgres-replication:12.3
+    links:
+      - postgres
+    environment:
+      POSTGRES_USER: nebirhos
+      POSTGRES_PASSWORD: password
+      REPLICATION_USER: nebirhos_rep
+      REPLICATION_PASSWORD: password
+      REPLICATION_ROLE: slave
+      POSTGRES_MASTER_SERVICE_HOST: postgres
+    expose:
+      - 5432
+    depends_on:
+      - postgres
+```
+
+## Run with Docker
 
 To run with Docker, first run the Postgres master:
 
-```
+```sh
 docker run -p 127.0.0.1:5432:5432 --name postgres-master nebirhos/postgres-replication
 ```
-
 
 Then Postgres slave(s):
 
@@ -50,12 +99,8 @@ docker run -p 127.0.0.1:5433:5432 --link postgres-master \
            -t nebirhos/postgres-replication
 ```
 
+## Notes
 
-Notes
------
+Replication is set up at container start by putting scripts in the `/docker-entrypoint-initdb.d` folder. This way the original Postgres image scripts are left untouched.
 
-Replication is set up at container start by putting scripts in the `/docker-entrypoint-initdb.d` folder.
-This way the original Postgres image scripts are left untouched.
-
-See [Dockerfile](Dockerfile) and [official Postgres image](https://hub.docker.com/_/postgres/)
-for custom environment variables.
+See [Dockerfile](Dockerfile) and [official Postgres image](https://hub.docker.com/_/postgres/) for custom environment variables.


### PR DESCRIPTION
I had compatibility for Postgres 12.3 version (maybe this is compatible as-is for newer version).

I also corrected `20-replication.sh` for `master` when you specify `POSTGRES_USER`.